### PR TITLE
Use TARGET_LINKER_FILE_NAME

### DIFF
--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -90,7 +90,7 @@ install(TARGETS ${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}
 # Generate to the devel space so the extras file can include it from the devel space.
 file(GENERATE
   OUTPUT "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake"
-  CONTENT "set(rviz_DEFAULT_PLUGIN_FILE_NAME $<TARGET_FILE_NAME:${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}>)"
+  CONTENT "set(rviz_DEFAULT_PLUGIN_FILE_NAME $<TARGET_LINKER_FILE_NAME:${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}>)"
 )
 # Install from the devel space to the install space.
 install(FILES "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake"


### PR DESCRIPTION
${rviz_DEFAULT_PLUGIN_FILE_NAME} eventually goes to${ rviz_DEFAULT_PLUGIN_LIBRARIES} to tell linker to know what to link. In Unix-like system, it is librviz_default_plugin.so and it is fine for LD. However, in Windows, linker takes the imported libraries. In this case, TARGET_LINKER_FILE_NAME generates rviz_default_plugin.DLL and it is a wrong input for the linker.

This change is using TARGET_LINKER_FILE_NAME to make the piece portable.