### PR TITLE
Fix interactive marker selection

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -164,7 +164,7 @@ public:
     {
       res = retriever_.get(file);
     }
-    catch (resource_retriever::Exception& e)
+    catch (resource_retriever::Exception&)
     {
       return false;
     }

--- a/src/rviz/selection/forwards.h
+++ b/src/rviz/selection/forwards.h
@@ -68,7 +68,7 @@ typedef boost::unordered_map<CollObjectHandle, Picked> M_Picked;
 inline uint32_t colorToHandle(Ogre::PixelFormat fmt, uint32_t col)
 {
   uint32_t handle = 0;
-  if (fmt == Ogre::PF_A8R8G8B8 || fmt == Ogre::PF_X8R8G8B8)
+  if (fmt == Ogre::PF_A8R8G8B8 || fmt == Ogre::PF_X8R8G8B8 || fmt == Ogre::PF_R8G8B8)
   {
     handle = col & 0x00ffffff;
   }

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -597,9 +597,11 @@ void SelectionManager::renderAndUnpack(Ogre::Viewport* viewport, uint32_t pass, 
     scheme << pass;
   }
 
-  if( render( viewport, render_textures_[pass], x1, y1, x2, y2, pixel_boxes_[pass], scheme.str(), texture_size_, texture_size_ ))
+  Ogre::PixelBox& box = pixel_boxes_[pass];
+
+  if( render( viewport, render_textures_[pass], x1, y1, x2, y2, box, scheme.str(), texture_size_, texture_size_ ))
   {
-    unpackColors(pixel_boxes_[pass], pixels);
+    unpackColors(box, pixels);
   }
 }
 
@@ -783,6 +785,9 @@ void SelectionManager::publishDebugImage( const Ogre::PixelBox& pixel_box, const
   int post_pixel_padding = 0;
   switch( pixel_box.format )
   {
+  case Ogre::PF_R8G8B8:
+	  break;
+
   case Ogre::PF_A8R8G8B8:
   case Ogre::PF_X8R8G8B8:
     post_pixel_padding = 1;


### PR DESCRIPTION
Passing the texture format to ogre is more of a guideline than a rule. Handle the case when it switches to a different texture format.