### PR TITLE
Revert common_msgs renames

### DIFF
--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -38,6 +38,9 @@
 #include <OgreSubEntity.h>
 #include <OgreMath.h>
 #include <OgreRenderWindow.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 
 #include <ros/ros.h>
 #include <interactive_markers/tools.h>

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
@@ -39,6 +39,9 @@
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 #endif
 
 #include <QCursor>

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -277,8 +277,8 @@ void MarkerDisplay::incomingMarker( const visualization_msgs::Marker::ConstPtr& 
 void MarkerDisplay::failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf::FilterFailureReason reason)
 {
   visualization_msgs::Marker::ConstPtr marker = marker_evt.getConstMessage();
-  if (marker->action == visualization_msgs::Marker::MK_DELETE ||
-      marker->action == 3)  // TODO: visualization_msgs::Marker::MK_DELETEALL when message changes in a future version of ROS
+  if (marker->action == visualization_msgs::Marker::DELETE ||
+      marker->action == 3)  // TODO: visualization_msgs::Marker::DELETEALL when message changes in a future version of ROS
   {
     return this->processMessage(marker);
   }
@@ -332,15 +332,15 @@ void MarkerDisplay::processMessage( const visualization_msgs::Marker::ConstPtr& 
 
   switch ( message->action )
   {
-  case visualization_msgs::Marker::MK_ADD:
+  case visualization_msgs::Marker::ADD:
     processAdd( message );
     break;
 
-  case visualization_msgs::Marker::MK_DELETE:
+  case visualization_msgs::Marker::DELETE:
     processDelete( message );
     break;
 
-  case 3: // TODO: visualization_msgs::Marker::MK_DELETEALL when message changes in a future version of ROS
+  case 3: // TODO: visualization_msgs::Marker::DELETEALL when message changes in a future version of ROS
     deleteAllMarkers();
     break;
 

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -32,6 +32,9 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreEntity.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 
 #include "rviz/default_plugin/marker_display.h"
 #include "rviz/default_plugin/markers/marker_selection_handler.h"

--- a/src/rviz/default_plugin/markers/triangle_list_marker.h
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.h
@@ -32,6 +32,9 @@
 
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 
 #include "rviz/default_plugin/markers/marker_base.h"
 

--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -47,6 +47,9 @@
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSharedPtr.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 
 
 namespace Ogre

--- a/src/rviz/ogre_helpers/point_cloud.h
+++ b/src/rviz/ogre_helpers/point_cloud.h
@@ -50,6 +50,9 @@
 #include <OgreRoot.h>
 #include <OgreHardwareBufferManager.h>
 #include <OgreSharedPtr.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 
 #ifndef _WIN32
 # pragma GCC diagnostic pop

--- a/src/rviz/selection/selection_handler.h
+++ b/src/rviz/selection/selection_handler.h
@@ -39,6 +39,9 @@
 #include <boost/unordered_map.hpp>
 
 #include <OgreMovableObject.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 #endif
 
 #include "rviz/selection/forwards.h"

--- a/src/rviz/selection/selection_manager.h
+++ b/src/rviz/selection/selection_manager.h
@@ -49,6 +49,9 @@
 #include <OgreMovableObject.h>
 #include <OgreRenderQueueListener.h>
 #include <OgreSharedPtr.h>
+#ifdef DELETE
+#undef DELETE
+#endif
 #endif
 
 #include <vector>


### PR DESCRIPTION
This is part of a fix for https://github.com/ms-iot/ROSOnWindows/issues/34
* Revert common_msgs renames
* Add workaround to avoid ERROR macro defines from windows.h, which is included by OGRE headers.