### PR TITLE
Revert ogre_plugin_path hack.

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -168,13 +168,7 @@ void RenderSystem::setupDummyWindowId()
 
 void RenderSystem::loadOgrePlugins()
 {
-  std::string plugin_prefix = "";
-
-#ifdef Q_OS_WIN32
-  // ogre on Windows expects shared library resolution via LoadLibrary
-#else
-  plugin_prefix = get_ogre_plugin_path() + "/";
-#endif
+  std::string plugin_prefix = get_ogre_plugin_path() + "/";
 #ifdef Q_OS_MAC
   plugin_prefix += "lib";
 #endif


### PR DESCRIPTION
Before we had a bug that `@OGRE_PLUGIN_PATH@` (in `env_config.cpp.in`) was not correctly populated by CMake configuration process, so `get_ogre_plugin_path()` returns an empty string. Now that is fixed, and we should honor the path returned from `get_ogre_plugin_path()`.