### PR TITLE
Revert parent windows handle fix.

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -369,9 +369,7 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow(
   Ogre::RenderWindow *window = NULL;
 
   params["externalWindowHandle"] = Ogre::StringConverter::toString(window_id);
-#if !defined(Q_OS_WIN)
   params["parentWindowHandle"] = Ogre::StringConverter::toString(window_id);
-#endif
 
   params["externalGLControl"] = true;
 


### PR DESCRIPTION
window_id is an dummy id `0` on Windows, and it is okay to pass as `parentWindowHandle` like `externalWindowHandle`, so considered it is extra change not required to upstream.