### PR TITLE
revert the getPackagePath usage in VisualizationFrame.

### DIFF
--- a/src/rviz/load_resource.cpp
+++ b/src/rviz/load_resource.cpp
@@ -27,19 +27,19 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "load_resource.h"
 
+#include <boost/filesystem.hpp>
 #include <ros/package.h>
 #include <ros/ros.h>
 
 #include <QPixmapCache>
 #include <QPainter>
 
-#include "load_resource.h"
-
 namespace rviz
 {
 
-boost::filesystem::path getPackagePath(const QString& url )
+boost::filesystem::path getPath(const QString& url )
 {
   boost::filesystem::path path;
   std::string stdPath = url.toStdString();
@@ -78,7 +78,7 @@ QPixmap loadPixmap( QString url, bool fill_cache )
     return pixmap;
   }
 
-  boost::filesystem::path path = getPackagePath( url );
+  boost::filesystem::path path = getPath( url );
 
   // If something goes wrong here, we go on and store the empty pixmap,
   // so the error won't appear again anytime soon.

--- a/src/rviz/load_resource.h
+++ b/src/rviz/load_resource.h
@@ -41,7 +41,6 @@ namespace rviz
 // Helper functions to load resources based on their resource url,
 // e.g. "package://rviz/icons/package.png",
 // or "file:///home/user/.ros/config.yaml".
-boost::filesystem::path getPackagePath(const QString& url);
 
 /* @brief Try to load the pixmap url from disk or the cache.
  *        In case of a failure, the result will be an empty QPixmap.

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -695,9 +695,7 @@ void VisualizationFrame::markRecentConfig( const std::string& path )
 
 void VisualizationFrame::loadDisplayConfig( const QString& qpath )
 {
-  boost::filesystem::path displayConfig = getPackagePath(qpath);
-
-  std::string path = displayConfig.string();
+  std::string path = qpath.toStdString();
   std::string actual_load_path = path;
   if( !fs::exists( path ) || fs::is_directory( path ) || fs::is_empty( path ))
   {


### PR DESCRIPTION
- Revert `getPackagePath` usage in `VisualizationFrame::loadDisplayConfig`
- Revert `getPackagePath` renames back to `getPath`
- Revert some headers reorder back to the original code base.

I didn't revert the following code block in `getPath`, which appears still required on Windows:
```cpp
  else if (boost::filesystem::exists(stdPath))
  {
    path = stdPath;
  }
```