### PR TITLE
rework getpath for Windows.

### DIFF
--- a/src/rviz/load_resource.cpp
+++ b/src/rviz/load_resource.cpp
@@ -42,7 +42,6 @@ namespace rviz
 boost::filesystem::path getPath( QString url )
 {
   boost::filesystem::path path;
-  std::string stdPath = url.toStdString();
 
   if ( url.indexOf("package://", 0, Qt::CaseInsensitive) == 0 )
   {
@@ -55,9 +54,9 @@ boost::filesystem::path getPath( QString url )
   {
     path = url.section('/',2).toStdString();
   }
-  else if (boost::filesystem::exists(stdPath))
+  else if (boost::filesystem::exists(path))
   {
-    path = stdPath;
+    // On Windows, the path would be the file path without any protocol prefix (e.g., "c:\abc\def.rviz").
   }
   else
   {


### PR DESCRIPTION
- Get rid of stdPath temp variable.
- Add comments.