### PR TITLE
Rework the scale bug fix

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -598,8 +598,9 @@ float getMeshUnitRescale(const std::string& resource_path)
 
   // Use the resource retriever to get the data.
   const char * data = reinterpret_cast<const char * > (res.data.get());
-  xmlDoc.Parse(data);
-
+  // Parse() expects a null-terminated string. Otherwise, the buffer size should be specified.
+  xmlDoc.Parse(data, res.size);
+  
   // Find the appropriate element if it exists
   if(!xmlDoc.Error())
   {
@@ -612,17 +613,10 @@ float getMeshUnitRescale(const std::string& resource_path)
         tinyxml2::XMLElement *unitXml = assetXml->FirstChildElement("unit");
         if (unitXml && unitXml->Attribute("meter"))
         {
-          // Some files use a double sized value for scale, which does not process correctly on Windows 
-          double specifiedScale = 1.0;
-
           // Failing to convert leaves unit_scale as the default.
-          if(unitXml->QueryDoubleAttribute("meter", &specifiedScale) != 0)
-          {
+          if(unitXml->QueryFloatAttribute("meter", &unit_scale) != 0)
             ROS_WARN_STREAM("getMeshUnitRescale::Failed to convert unit element meter attribute to determine scaling. unit element: "
                             << unitXml->GetText());
-          }
-
-          unit_scale = (float)specifiedScale;
         }
       }
     }


### PR DESCRIPTION
So after some testing, the actual problem is that `MemoryResource` returns the buffer pointer and size but doesn't have the guarantee the buffer being null-terminated (which makes sense since `MemoryResource` could hold anything in binary format.)

However, xmlDoc.Parse() does require a null-terminated string, or a buffer size needs to be specified. Otherwise, when the parser reads the bytes beyond the actual buffer size, it will lead to unexpected behavior (In my observation, this issue will manifest as `XML_ERROR_PARSING_TEXT` error.) and a scale of 1.0 will be returned.

So, specify the buffer size when calling Parse() to make sure it only reads till the buffer end.

And revert the QueryDoubleAttribute change since it is not the actual root cause of the problem.